### PR TITLE
Fixes background script improperly incrementing badge number

### DIFF
--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -36,7 +36,8 @@ export class AppComponent implements OnInit {
       chrome.storage.sync.set({connections});
     });
 
-    chrome.browserAction.setBadgeText({text: ""});
+    // We'll tell the background script that the popup is open
+    chrome.runtime.connect();
     this.sidenavService.setSidenav(this.sidenav);
   }
 

--- a/src/background.ts
+++ b/src/background.ts
@@ -1,22 +1,47 @@
+import {Subject} from "rxjs";
+import {takeUntil} from "rxjs/operators";
 import {GotifySocket} from "./app/classes/gotify-socket";
 import {SocketService} from "./app/services/socket.service";
 
 chrome.runtime.onInstalled.addListener(() => {
   const socket = new SocketService();
 
+  const destroy$: Subject<boolean> = new Subject<boolean>();
+  let connections: GotifySocket[];
   socket.loadConnections().then(() => {
+    // I don't know why, but if I remove this, the counter in the notifications breaks. Maybe I'll look into it some day
+    socket.sockets.subscribe((sockets) => {
+      connections = sockets;
+    });
 
-    chrome.storage.onChanged.addListener((changes, namespace) => {
-      const connections = changes.connections.newValue;
-      for (const connectionInfo of connections) {
-        socket.open(connectionInfo.url, connectionInfo.token);
-      }
+    let unreadCount = 0;
+    let isOpen = false;
+
+    chrome.runtime.onConnect.addListener((port) => {
+      isOpen = true;
+      chrome.browserAction.setBadgeText({text: ""});
+      port.onDisconnect.addListener(() => {
+        unreadCount = 0;
+        isOpen = false;
+      });
+    });
+
+    socket.$.pipe(takeUntil(destroy$)).subscribe((gotify: GotifySocket) => {
+      gotify.GetMessageSubscription().subscribe((_) => {
+        if (!isOpen) {
+          unreadCount++;
+          chrome.browserAction.setBadgeText({text: unreadCount.toString()});
+        }
+      });
     });
   });
 
-  let unreadCount = 0;
-  socket.initSocket().subscribe((gotify: GotifySocket) => gotify.GetMessageSubscription().subscribe((_) => {
-    unreadCount++;
-    chrome.browserAction.setBadgeText({text: unreadCount.toString()});
-  }));
+  chrome.storage.onChanged.addListener((changes, namespace) => {
+    if (changes.connections) {
+      const newConnections = changes.connections.newValue || [];
+      for (const connectionInfo of newConnections) {
+        socket.open(connectionInfo.url, connectionInfo.token);
+      }
+    }
+  });
 });


### PR DESCRIPTION
- When the popup opens, a connection is made to the background script
- the background script then resets the badge, and the unread count, and will not increment while the popup is open

Fixes #11 